### PR TITLE
Added two new expression types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,5 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+quote_type = single
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,4 +11,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 quote_type = single
-
+max_line_length = 120

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,4 +11,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 quote_type = single
-max_line_length = 120
+max_line_length = 140

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,26 +1,23 @@
 {
-	"env": {
-		"browser": true,
-		"es2021": true,
-		"node": true
-	},
-	"extends": [
-		"airbnb-typescript/base"
-	],
-	"parser": "@typescript-eslint/parser",
-	"parserOptions": {
-		"ecmaVersion": 12,
-		"sourceType": "module",
-		"project": "./tsconfig.eslint.json"
-	},
-	"plugins": [
-		"@typescript-eslint"
-	],
-	"rules": {
-		"no-tabs": "off",
-		"indent": "off",
-		"no-plusplus":"off",
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["airbnb-typescript/base"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module",
+    "project": "./tsconfig.eslint.json"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "no-tabs": "off",
+    "indent": "off",
+    "no-plusplus": "off",
     "max-classes-per-file": "off",
-    "max-len": ["error", { "code": 140 }]
-	}
+    "max-len": ["error", { "code": 140 }],
+    "trailingComma": "none"
+  }
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -8,7 +8,9 @@ export type Expression =
   | IdentifierExpression
   | CaseExpression
   | InExpression
-  | HasExpression;
+  | HasExpression
+  | GroupExpression
+  | NotExpression;
 
 export interface Node {
   readonly type:
@@ -19,7 +21,9 @@ export interface Node {
     | 'IdentifierExpression'
     | 'CaseExpression'
     | 'InExpression'
-    | 'HasExpression';
+    | 'HasExpression'
+    | 'GroupExpression'
+    | 'NotExpression';
 }
 
 export class BinaryExpression implements Node {
@@ -66,9 +70,8 @@ export class CaseExpression implements Node {
 
 export class InExpression implements Node {
   constructor(
-    public identifier: IdentifierExpression,
-    public values: ValueExpression[],
-    public operator?: TokenType
+    public left: IdentifierExpression | GroupExpression,
+    public right: IdentifierExpression | GroupExpression
   ) {}
 
   readonly type = 'InExpression';
@@ -77,9 +80,20 @@ export class InExpression implements Node {
 export class HasExpression implements Node {
   constructor(
     public identifier: IdentifierExpression,
-    public condition: Expression,
-    public operator?: TokenType
+    public condition: Expression
   ) {}
 
   readonly type = 'HasExpression';
+}
+
+export class NotExpression implements Node {
+  constructor(public expression: Expression) {}
+
+  readonly type = 'NotExpression';
+}
+
+export class GroupExpression implements Node {
+  constructor(public values: Expression[]) {}
+
+  readonly type = 'GroupExpression';
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -60,10 +60,7 @@ export class CaseExpression implements Node {
 }
 
 export class InExpression implements Node {
-  constructor(
-    public left: IdentifierExpression | GroupExpression,
-    public right: IdentifierExpression | GroupExpression
-  ) {}
+  constructor(public left: IdentifierExpression | GroupExpression, public right: IdentifierExpression | GroupExpression) {}
 
   readonly type = 'InExpression';
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -8,7 +8,6 @@ export type Expression =
   | IdentifierExpression
   | CaseExpression
   | InExpression
-  | HasExpression
   | GroupExpression
   | NotExpression;
 
@@ -21,7 +20,6 @@ export interface Node {
     | 'IdentifierExpression'
     | 'CaseExpression'
     | 'InExpression'
-    | 'HasExpression'
     | 'GroupExpression'
     | 'NotExpression';
 }
@@ -75,15 +73,6 @@ export class InExpression implements Node {
   ) {}
 
   readonly type = 'InExpression';
-}
-
-export class HasExpression implements Node {
-  constructor(
-    public identifier: IdentifierExpression,
-    public condition: Expression
-  ) {}
-
-  readonly type = 'HasExpression';
 }
 
 export class NotExpression implements Node {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -25,11 +25,7 @@ export interface Node {
 }
 
 export class BinaryExpression implements Node {
-  constructor(
-    public operator: TokenType,
-    public left: Expression,
-    public right: Expression
-  ) {}
+  constructor(public operator: TokenType, public left: Expression, public right: Expression) {}
 
   readonly type = 'BinaryExpression';
 }
@@ -58,10 +54,7 @@ export class IdentifierExpression implements Node {
   readonly type = 'IdentifierExpression';
 }
 export class CaseExpression implements Node {
-  constructor(
-    public conditions: { when: Expression; then: Expression }[],
-    public last?: Expression
-  ) {}
+  constructor(public conditions: { when: Expression; then: Expression }[], public last?: Expression) {}
 
   readonly type = 'CaseExpression';
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,52 +1,85 @@
 import { TokenType } from './token';
 
-export type Expression = BinaryExpression
-| UnaryExpression
-| ValueExpression
-| FunctionCallExpression
-| IdentifierExpression
-| CaseExpression;
+export type Expression =
+  | BinaryExpression
+  | UnaryExpression
+  | ValueExpression
+  | FunctionCallExpression
+  | IdentifierExpression
+  | CaseExpression
+  | InExpression
+  | HasExpression;
 
 export interface Node {
-  readonly type: 'BinaryExpression' |
-  'UnaryExpression' |
-  'ValueExpression' |
-  'FunctionCallExpression' |
-  'IdentifierExpression' |
-  'CaseExpression';
+  readonly type:
+    | 'BinaryExpression'
+    | 'UnaryExpression'
+    | 'ValueExpression'
+    | 'FunctionCallExpression'
+    | 'IdentifierExpression'
+    | 'CaseExpression'
+    | 'InExpression'
+    | 'HasExpression';
 }
 
 export class BinaryExpression implements Node {
-  constructor(public operator: TokenType, public left: Expression, public right: Expression) { }
+  constructor(
+    public operator: TokenType,
+    public left: Expression,
+    public right: Expression
+  ) {}
 
   readonly type = 'BinaryExpression';
 }
 
 export class UnaryExpression implements Node {
-  constructor(public operator: TokenType, public operand: Expression) { }
+  constructor(public operator: TokenType, public operand: Expression) {}
 
   readonly type = 'UnaryExpression';
 }
 
 export class ValueExpression implements Node {
-  constructor(public value: any) { }
+  constructor(public value: any) {}
 
   readonly type = 'ValueExpression';
 }
 
 export class FunctionCallExpression implements Node {
-  constructor(public name: string, public args: Expression[]) { }
+  constructor(public name: string, public args: Expression[]) {}
 
   readonly type = 'FunctionCallExpression';
 }
 
 export class IdentifierExpression implements Node {
-  constructor(public name: string) { }
+  constructor(public name: string) {}
 
   readonly type = 'IdentifierExpression';
 }
 export class CaseExpression implements Node {
-  constructor(public conditions: { when: Expression, then: Expression }[], public last?: Expression) { }
+  constructor(
+    public conditions: { when: Expression; then: Expression }[],
+    public last?: Expression
+  ) {}
 
   readonly type = 'CaseExpression';
+}
+
+export class InExpression implements Node {
+  constructor(
+    public identifier: IdentifierExpression,
+    public values: ValueExpression[],
+    public operator?: TokenType
+  ) {}
+
+  readonly type = 'InExpression';
+}
+
+export class HasExpression implements Node {
+  constructor(
+    public identifier: IdentifierExpression,
+    public condition: Expression,
+    public operator?: TokenType
+  ) {}
+
+  readonly type = 'HasExpression';
 }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1,8 +1,18 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import { BinaryExpression, CaseExpression, Expression } from './ast';
+import {
+  BinaryExpression,
+  CaseExpression,
+  InExpression,
+  HasExpression,
+  Expression,
+} from './ast';
 import { parse } from './parser';
+import { TokenType } from './token';
 
-function evaluateExpressions(expressions: Expression[], context?: (identifier: string) => any): any[] {
+function evaluateExpressions(
+  expressions: Expression[],
+  context?: (identifier: string) => any
+): any[] {
   return expressions.map((exp) => evaluateExpression(exp, context));
 }
 
@@ -18,38 +28,80 @@ function evaluateFunctionCall(name: string, args: any[]): any {
   }
 }
 
-function evaluateBinaryExpression(expression: BinaryExpression, context?: (identifier: string) => any): any {
+function evaluateBinaryExpression(
+  expression: BinaryExpression,
+  context?: (identifier: string) => any
+): any {
   switch (expression.operator) {
     case '+':
-      return evaluateExpression(expression.left, context) + evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) +
+        evaluateExpression(expression.right, context)
+      );
     case '-':
-      return evaluateExpression(expression.left, context) - evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) -
+        evaluateExpression(expression.right, context)
+      );
     case '*':
-      return evaluateExpression(expression.left, context) * evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) *
+        evaluateExpression(expression.right, context)
+      );
     case '/':
-      return evaluateExpression(expression.left, context) / evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) /
+        evaluateExpression(expression.right, context)
+      );
     case '=':
-      return evaluateExpression(expression.left, context) === evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) ===
+        evaluateExpression(expression.right, context)
+      );
     case '<>':
-      return evaluateExpression(expression.left, context) !== evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) !==
+        evaluateExpression(expression.right, context)
+      );
     case '>':
-      return evaluateExpression(expression.left, context) > evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) >
+        evaluateExpression(expression.right, context)
+      );
     case '>=':
-      return evaluateExpression(expression.left, context) >= evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) >=
+        evaluateExpression(expression.right, context)
+      );
     case '<':
-      return evaluateExpression(expression.left, context) < evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) <
+        evaluateExpression(expression.right, context)
+      );
     case '<=':
-      return evaluateExpression(expression.left, context) <= evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) <=
+        evaluateExpression(expression.right, context)
+      );
     case 'and':
-      return evaluateExpression(expression.left, context) && evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) &&
+        evaluateExpression(expression.right, context)
+      );
     case 'or':
-      return evaluateExpression(expression.left, context) || evaluateExpression(expression.right, context);
+      return (
+        evaluateExpression(expression.left, context) ||
+        evaluateExpression(expression.right, context)
+      );
     default:
       throw new Error(`Operator ${expression.operator} not implemented`);
   }
 }
 
-function evaluateCaseExpression(expression: CaseExpression, context?: (identifier: string) => any): any {
+function evaluateCaseExpression(
+  expression: CaseExpression,
+  context?: (identifier: string) => any
+): any {
   for (let index = 0; index < expression.conditions.length; index++) {
     const cond = expression.conditions[index];
     if (evaluateExpression(cond.when, context)) {
@@ -62,24 +114,74 @@ function evaluateCaseExpression(expression: CaseExpression, context?: (identifie
   return false;
 }
 
-function evaluateExpression(expression: Expression, context?: (identifier: string) => any): any {
+function evaluateInExpression(
+  expression: InExpression,
+  context?: (identifier: string) => any
+): any {
+  const operator = expression.operator;
+  const value = evaluateExpression(expression.identifier, context);
+  if (value == null) {
+    return false;
+  }
+  const values = expression.values.map((v) => evaluateExpression(v, context));
+  const index = values.indexOf(value);
+  return operator === TokenType.Not ? index === -1 : index !== -1;
+}
+
+function evaluateHasExpression(
+  expression: HasExpression,
+  context?: (identifier: string) => any
+): any {
+  const value = evaluateExpression(expression.identifier, context);
+  const isArray = Array.isArray(value);
+  if (!isArray && (typeof value !== 'object' || value === null)) {
+    return false;
+  }
+
+  const isValue = expression.condition.type === 'ValueExpression';
+  const condition = isArray
+    ? value.some((v: any) =>
+        isValue
+          ? v === evaluateExpression(expression.condition, context)
+          : evaluateExpression(expression.condition, (name: any) => v[name])
+      )
+    : isValue
+    ? value === evaluateExpression(expression.condition, context)
+    : evaluateExpression(expression.condition, (name: any) => value[name]);
+  return expression.operator === TokenType.Not ? !condition : condition;
+}
+
+function evaluateExpression(
+  expression: Expression,
+  context?: (identifier: string) => any
+): any {
   switch (expression.type) {
     case 'IdentifierExpression':
       return context!(expression.name);
     case 'ValueExpression':
       return expression.value;
     case 'FunctionCallExpression':
-      return evaluateFunctionCall(expression.name, evaluateExpressions(expression.args, context));
+      return evaluateFunctionCall(
+        expression.name,
+        evaluateExpressions(expression.args, context)
+      );
     case 'BinaryExpression':
       return evaluateBinaryExpression(expression, context);
     case 'CaseExpression':
       return evaluateCaseExpression(expression, context);
+    case 'InExpression':
+      return evaluateInExpression(expression, context);
+    case 'HasExpression':
+      return evaluateHasExpression(expression, context);
     default:
       throw new Error(`Invalid AST node${expression}`);
   }
 }
 
-export function evaluate(expression: string, context?: (identifier: string) => any): any {
+export function evaluate(
+  expression: string,
+  context?: (identifier: string) => any
+): any {
   const ast = parse(expression);
   return evaluateExpression(ast, context);
 }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1,18 +1,9 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import {
-  BinaryExpression,
-  CaseExpression,
-  InExpression,
-  Expression,
-  GroupExpression,
-} from './ast';
+import { BinaryExpression, CaseExpression, InExpression, Expression, GroupExpression } from './ast';
 import { parse } from './parser';
 import { TokenType } from './token';
 
-function evaluateExpressions(
-  expressions: Expression[],
-  context?: (identifier: string) => any
-): any[] {
+function evaluateExpressions(expressions: Expression[], context?: (identifier: string) => any): any[] {
   return expressions.map((exp) => evaluateExpression(exp, context));
 }
 
@@ -28,80 +19,38 @@ function evaluateFunctionCall(name: string, args: any[]): any {
   }
 }
 
-function evaluateBinaryExpression(
-  expression: BinaryExpression,
-  context?: (identifier: string) => any
-): any {
+function evaluateBinaryExpression(expression: BinaryExpression, context?: (identifier: string) => any): any {
   switch (expression.operator) {
     case '+':
-      return (
-        evaluateExpression(expression.left, context) +
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) + evaluateExpression(expression.right, context);
     case '-':
-      return (
-        evaluateExpression(expression.left, context) -
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) - evaluateExpression(expression.right, context);
     case '*':
-      return (
-        evaluateExpression(expression.left, context) *
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) * evaluateExpression(expression.right, context);
     case '/':
-      return (
-        evaluateExpression(expression.left, context) /
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) / evaluateExpression(expression.right, context);
     case '=':
-      return (
-        evaluateExpression(expression.left, context) ===
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) === evaluateExpression(expression.right, context);
     case '<>':
-      return (
-        evaluateExpression(expression.left, context) !==
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) !== evaluateExpression(expression.right, context);
     case '>':
-      return (
-        evaluateExpression(expression.left, context) >
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) > evaluateExpression(expression.right, context);
     case '>=':
-      return (
-        evaluateExpression(expression.left, context) >=
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) >= evaluateExpression(expression.right, context);
     case '<':
-      return (
-        evaluateExpression(expression.left, context) <
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) < evaluateExpression(expression.right, context);
     case '<=':
-      return (
-        evaluateExpression(expression.left, context) <=
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) <= evaluateExpression(expression.right, context);
     case 'and':
-      return (
-        evaluateExpression(expression.left, context) &&
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) && evaluateExpression(expression.right, context);
     case 'or':
-      return (
-        evaluateExpression(expression.left, context) ||
-        evaluateExpression(expression.right, context)
-      );
+      return evaluateExpression(expression.left, context) || evaluateExpression(expression.right, context);
     default:
       throw new Error(`Operator ${expression.operator} not implemented`);
   }
 }
 
-function evaluateCaseExpression(
-  expression: CaseExpression,
-  context?: (identifier: string) => any
-): any {
+function evaluateCaseExpression(expression: CaseExpression, context?: (identifier: string) => any): any {
   for (let index = 0; index < expression.conditions.length; index++) {
     const cond = expression.conditions[index];
     if (evaluateExpression(cond.when, context)) {
@@ -115,18 +64,12 @@ function evaluateCaseExpression(
 }
 
 const invalidLeftSide = 'Invalid left side of IN expression';
-function evaluateInExpression(
-  expression: InExpression,
-  context?: (identifier: string) => any
-): any {
+function evaluateInExpression(expression: InExpression, context?: (identifier: string) => any): any {
   const { left, right } = expression;
   const leftValue = evaluateExpression(left, context);
   const rightValues = evaluateExpression(right, context);
 
-  if (
-    left.type === 'GroupExpression' &&
-    right.type === 'IdentifierExpression'
-  ) {
+  if (left.type === 'GroupExpression' && right.type === 'IdentifierExpression') {
     if (!Array.isArray(leftValue)) {
       throw new Error(invalidLeftSide);
     }
@@ -137,10 +80,7 @@ function evaluateInExpression(
       throw new Error('Right side of IN expression must be an array');
     }
     return leftValue.every((v) => rightValues.indexOf(v) !== -1);
-  } else if (
-    left.type === 'IdentifierExpression' &&
-    right.type === 'GroupExpression'
-  ) {
+  } else if (left.type === 'IdentifierExpression' && right.type === 'GroupExpression') {
     if (leftValue == null) {
       throw new Error(`${left.name} is not defined`);
     } else {
@@ -157,28 +97,19 @@ function evaluateInExpression(
   }
 }
 
-function evaluateGroupExpression(
-  expression: GroupExpression,
-  context?: (identifier: string) => any
-): any {
+function evaluateGroupExpression(expression: GroupExpression, context?: (identifier: string) => any): any {
   const values = expression.values.map((v) => evaluateExpression(v, context));
   return values;
 }
 
-function evaluateExpression(
-  expression: Expression,
-  context?: (identifier: string) => any
-): any {
+function evaluateExpression(expression: Expression, context?: (identifier: string) => any): any {
   switch (expression.type) {
     case 'IdentifierExpression':
       return context!(expression.name);
     case 'ValueExpression':
       return expression.value;
     case 'FunctionCallExpression':
-      return evaluateFunctionCall(
-        expression.name,
-        evaluateExpressions(expression.args, context)
-      );
+      return evaluateFunctionCall(expression.name, evaluateExpressions(expression.args, context));
     case 'BinaryExpression':
       return evaluateBinaryExpression(expression, context);
     case 'CaseExpression':
@@ -194,10 +125,7 @@ function evaluateExpression(
   }
 }
 
-export function evaluate(
-  expression: string,
-  context?: (identifier: string) => any
-): any {
+export function evaluate(expression: string, context?: (identifier: string) => any): any {
   const ast = parse(expression);
   return evaluateExpression(ast, context);
 }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { BinaryExpression, CaseExpression, InExpression, Expression, GroupExpression } from './ast';
 import { parse } from './parser';
-import { TokenType } from './token';
 
 function evaluateExpressions(expressions: Expression[], context?: (identifier: string) => any): any[] {
   return expressions.map((exp) => evaluateExpression(exp, context));

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -134,7 +134,6 @@ function evaluateInExpression(
       throw new Error(`${right.name} is not defined`);
     }
     if (!Array.isArray(rightValues)) {
-      // TODO
       throw new Error('Right side of IN expression must be an array');
     }
     return leftValue.every((v) => rightValues.indexOf(v) !== -1);

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -82,10 +82,7 @@ export class Lexer {
           } else {
             token = this.getToken(identType);
           }
-        } else if (
-          Lexer.isNumber(this.currentChar) ||
-          Lexer.isDot(this.currentChar)
-        ) {
+        } else if (Lexer.isNumber(this.currentChar) || Lexer.isDot(this.currentChar)) {
           const num = this.readNumber();
           token = this.getToken(TokenType.Numeric, num);
         } else {
@@ -139,10 +136,7 @@ export class Lexer {
   private readNumber(): string {
     const start = this.position;
     let haveDecimal = Lexer.isDot(this.currentChar);
-    while (
-      Lexer.isNumber(this.peekChar()) ||
-      (Lexer.isDot(this.peekChar()) && !haveDecimal)
-    ) {
+    while (Lexer.isNumber(this.peekChar()) || (Lexer.isDot(this.peekChar()) && !haveDecimal)) {
       if (Lexer.isDot(this.currentChar)) {
         haveDecimal = true;
       }

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -1,6 +1,6 @@
 import { Token, TokenType } from './token';
 
-export interface Tokenizer{
+export interface Tokenizer {
   next(): Token;
 }
 
@@ -82,7 +82,10 @@ export class Lexer {
           } else {
             token = this.getToken(identType);
           }
-        } else if (Lexer.isNumber(this.currentChar) || Lexer.isDot(this.currentChar)) {
+        } else if (
+          Lexer.isNumber(this.currentChar) ||
+          Lexer.isDot(this.currentChar)
+        ) {
           const num = this.readNumber();
           token = this.getToken(TokenType.Numeric, num);
         } else {
@@ -136,7 +139,10 @@ export class Lexer {
   private readNumber(): string {
     const start = this.position;
     let haveDecimal = Lexer.isDot(this.currentChar);
-    while (Lexer.isNumber(this.peekChar()) || (Lexer.isDot(this.peekChar()) && !haveDecimal)) {
+    while (
+      Lexer.isNumber(this.peekChar()) ||
+      (Lexer.isDot(this.peekChar()) && !haveDecimal)
+    ) {
       if (Lexer.isDot(this.currentChar)) {
         haveDecimal = true;
       }
@@ -155,10 +161,10 @@ export class Lexer {
   private static isWhiteSpace(charStr: string): boolean {
     const charCode = charStr.charCodeAt(0);
     return (
-      charCode === 0x09 // '\t'
-      || charCode === 0x0a // '\n'
-      || charCode === 0x0d // '\r'
-      || charCode === 0x20 // ' '
+      charCode === 0x09 || // '\t'
+      charCode === 0x0a || // '\n'
+      charCode === 0x0d || // '\r'
+      charCode === 0x20 // ' '
     );
   }
 
@@ -170,9 +176,9 @@ export class Lexer {
   private static isLetter(charStr: string): boolean {
     const charCode = charStr.charCodeAt(0);
     return (
-      (charCode >= 0x41 && charCode <= 0x5a) // A-Z
-      || (charCode >= 0x61 && charCode <= 0x7a) // a-z
-      || charCode === 0x5f // '_'
+      (charCode >= 0x41 && charCode <= 0x5a) || // A-Z
+      (charCode >= 0x61 && charCode <= 0x7a) || // a-z
+      charCode === 0x5f // '_'
     );
   }
 
@@ -194,6 +200,8 @@ export class Lexer {
     else: TokenType.Else,
     end: TokenType.End,
     then: TokenType.Then,
+    in: TokenType.In,
+    has: TokenType.Has,
   };
 
   private static resolveIdentifier(ident: string): TokenType {

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -201,7 +201,6 @@ export class Lexer {
     end: TokenType.End,
     then: TokenType.Then,
     in: TokenType.In,
-    has: TokenType.Has,
   };
 
   private static resolveIdentifier(ident: string): TokenType {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -179,10 +179,7 @@ export class Parser {
   private parseInExpression(left: Expression | Expression[]): Expression {
     this.nextToken();
     const expression = this.parseExpression(this.currentPrecedence);
-    return new InExpression(
-      left as GroupExpression | IdentifierExpression,
-      expression as GroupExpression | IdentifierExpression
-    );
+    return new InExpression(left as GroupExpression | IdentifierExpression, expression as GroupExpression | IdentifierExpression);
   }
 
   private parseIsExpression(left: Expression): Expression {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -100,9 +100,6 @@ export class Parser {
       throw new Error(`Unexpected start of expression: ${this.currentToken}`);
     }
     let leftExpression = prefixParser();
-    // console.log('---- parseExpression ----');
-    // console.log(this.currentToken, this.peekToken);
-    // console.log(precedence, this.peekPrecedence);
     while (
       precedence < this.peekPrecedence &&
       !this.currentTokenIs(TokenType.EOF)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -223,7 +223,7 @@ export class Parser {
       );
     }
     this.nextToken();
-    const expression = this.parseExpression(3);
+    const expression = this.parseExpression(precedences[TokenType.Not]);
     return new HasExpression(
       name as IdentifierExpression,
       expression,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -100,10 +100,7 @@ export class Parser {
       throw new Error(`Unexpected start of expression: ${this.currentToken}`);
     }
     let leftExpression = prefixParser();
-    while (
-      precedence < this.peekPrecedence &&
-      !this.currentTokenIs(TokenType.EOF)
-    ) {
+    while (precedence < this.peekPrecedence && !this.currentTokenIs(TokenType.EOF)) {
       const infixParser = this.infixParsers[this.peekToken.type];
       if (!infixParser) {
         return leftExpression;
@@ -168,11 +165,7 @@ export class Parser {
     const { currentPrecedence } = this;
     const op = this.currentToken.type;
     this.nextToken();
-    return new BinaryExpression(
-      op,
-      left,
-      this.parseExpression(currentPrecedence)
-    );
+    return new BinaryExpression(op, left, this.parseExpression(currentPrecedence));
   }
 
   private parseNotExpression(left: Expression): Expression {
@@ -221,10 +214,7 @@ export class Parser {
     while (!this.currentTokenIs(TokenType.Rparn)) {
       args.push(this.parseExpression());
       this.nextToken();
-      if (
-        !this.currentTokenIs(TokenType.Comma) &&
-        !this.currentTokenIs(TokenType.Rparn)
-      ) {
+      if (!this.currentTokenIs(TokenType.Comma) && !this.currentTokenIs(TokenType.Rparn)) {
         throw new Error(`Expected , or ) got ${this.currentToken}`);
       }
     }
@@ -244,10 +234,7 @@ export class Parser {
     if (!this.peekTokenIs(TokenType.When)) {
       throw new Error(`Expected when got ${this.currentToken}`);
     }
-    while (
-      !this.peekTokenIs(TokenType.End) &&
-      !this.peekTokenIs(TokenType.Else)
-    ) {
+    while (!this.peekTokenIs(TokenType.End) && !this.peekTokenIs(TokenType.Else)) {
       this.expectPeekToken(TokenType.When);
       this.nextToken();
       const when = this.parseExpression();

--- a/src/token.ts
+++ b/src/token.ts
@@ -41,7 +41,6 @@ export enum TokenType {
   Then = 'then',
 
   In = 'in',
-  Has = 'has',
 }
 
 export class Token {

--- a/src/token.ts
+++ b/src/token.ts
@@ -44,11 +44,7 @@ export enum TokenType {
 }
 
 export class Token {
-  constructor(
-    public type: TokenType,
-    public literal: string,
-    public position: Number
-  ) {}
+  constructor(public type: TokenType, public literal: string, public position: Number) {}
 
   toString(): string {
     return `{ type: ${this.type}, literal: ${this.literal} } as position: ${this.position}.`;

--- a/src/token.ts
+++ b/src/token.ts
@@ -39,13 +39,16 @@ export enum TokenType {
   Else = 'else',
   End = 'end',
   Then = 'then',
+
+  In = 'in',
+  Has = 'has',
 }
 
 export class Token {
   constructor(
     public type: TokenType,
     public literal: string,
-    public position: Number,
+    public position: Number
   ) {}
 
   toString(): string {

--- a/tests/evaluator.spec.ts
+++ b/tests/evaluator.spec.ts
@@ -11,7 +11,13 @@ describe('Evaluator tests', () => {
 
   it('should solve basic math equations with object context', () => {
     const context = {
-      a: 1, b: 2, c: 10, d: 6, e: 100, f: 12, g: 14,
+      a: 1,
+      b: 2,
+      c: 10,
+      d: 6,
+      e: 100,
+      f: 12,
+      g: 14,
     };
     expect(evaluateObject('a+b', context)).toBe(3);
     expect(evaluateObject('c + b * d', context)).toBe(22);
@@ -27,7 +33,12 @@ describe('Evaluator tests', () => {
 
   it('should validate string range', () => {
     const val = { a: 'xyz', b: 'asd123asd' };
-    expect(evaluateObject('length(a) between 1 and 3 and length(b) between 1 and 9', val)).toBe(true);
+    expect(
+      evaluateObject(
+        'length(a) between 1 and 3 and length(b) between 1 and 9',
+        val
+      )
+    ).toBe(true);
   });
 
   it('should check string length', () => {
@@ -47,20 +58,32 @@ describe('Evaluator tests', () => {
 
   it('should check string is not null and has length between 4 and 10', () => {
     const val = { a: '1234' };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(true);
+    expect(
+      evaluateObject('a is not null and length(a) between 4 and 10', val)
+    ).toBe(true);
   });
 
   it('should check string is not null and has length between 4 and 10', () => {
     let val: any = { a: null };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(false);
+    expect(
+      evaluateObject('a is not null and length(a) between 4 and 10', val)
+    ).toBe(false);
     val = { a: '123' };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(false);
+    expect(
+      evaluateObject('a is not null and length(a) between 4 and 10', val)
+    ).toBe(false);
     val = { a: '1234' };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(true);
+    expect(
+      evaluateObject('a is not null and length(a) between 4 and 10', val)
+    ).toBe(true);
     val = { a: '1234567890' };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(true);
+    expect(
+      evaluateObject('a is not null and length(a) between 4 and 10', val)
+    ).toBe(true);
     val = { a: '12345678901' };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(false);
+    expect(
+      evaluateObject('a is not null and length(a) between 4 and 10', val)
+    ).toBe(false);
   });
 
   it('should compare variables', () => {
@@ -84,13 +107,26 @@ describe('Evaluator tests', () => {
   });
   it('should evaluate case expressions', () => {
     let val: any = { a: 1, b: 3 };
-    expect(evaluateObject('case when a > 1 then true else false end', val)).toBe(false);
+    expect(
+      evaluateObject('case when a > 1 then true else false end', val)
+    ).toBe(false);
     val = { a: 2, b: 3 };
-    expect(evaluateObject('case when a > 1 then true else false end', val)).toBe(true);
+    expect(
+      evaluateObject('case when a > 1 then true else false end', val)
+    ).toBe(true);
     val = { a: 2, b: 3 };
-    expect(evaluateObject('case when a = 1 then 1 when a = 2 then 1 else false end', val)).toBe(1);
-    expect(evaluateObject('case when a = 1 then 1 when a = 2 then 2 else 3 end', val)).toBe(2);
-    expect(evaluateObject('case when a = 1 then 1 when a = 3 then 3 else 2 end', val)).toBe(2);
+    expect(
+      evaluateObject(
+        'case when a = 1 then 1 when a = 2 then 1 else false end',
+        val
+      )
+    ).toBe(1);
+    expect(
+      evaluateObject('case when a = 1 then 1 when a = 2 then 2 else 3 end', val)
+    ).toBe(2);
+    expect(
+      evaluateObject('case when a = 1 then 1 when a = 3 then 3 else 2 end', val)
+    ).toBe(2);
     const rule = `case
                     when light = 'Green' then 'Go'
                     when light = 'Yellow' then 'Should Stop'
@@ -104,5 +140,93 @@ describe('Evaluator tests', () => {
     expect(evaluateObject(rule, val)).toBe('Stop');
     val = { light: 'Blue' };
     expect(evaluateObject(rule, val)).toBe('Invalid State');
+  });
+  it('should evaluate in expressions', () => {
+    let val: any = { a: 1, b: 3, c: [2, 3, 5] };
+    const rule = `b in (1,2,3,4,5)`;
+    expect(evaluateObject(`b in (1,2,3,4,5)`, val)).toBe(true);
+    val = { light: 'Blue' };
+    expect(evaluateObject(`b in (1,2,3,4,5)`, val)).toBe(false);
+    val = { b: ['oj', 'oj', 'pl'] };
+    expect(evaluateObject(`b in (1,2,3,4,5)`, val)).toBe(false);
+    expect(evaluateObject(`b in (oj,pl)`, val)).toBe(false);
+    val = { b: 'Blue' };
+    expect(evaluateObject(`b in ('Blue','Green')`, val)).toBe(true);
+    val = { b: 'Green' };
+    expect(evaluateObject(`b in ('Blue','Green', "Yellow")`, val)).toBe(true);
+    val = { b: 'Green' };
+    expect(evaluateObject(`b not in ('Blue','Green', "RED")`, val)).toBe(false);
+    val = { a: 'Green' };
+    expect(evaluateObject(`b not in ('Blue','Green', "RED")`, val)).toBe(false);
+  });
+  it('should evaluate has expressions', () => {
+    let val: any = { a: { x: 7 } };
+    expect(evaluateObject(`a has x = 7`, val)).toBe(true);
+    val = { a: [] };
+    expect(evaluateObject(`a has x = 7`, val)).toBe(false);
+    val = { a: [{ x: 8 }] };
+    expect(evaluateObject(`a has x = 7`, val)).toBe(false);
+    val = { a: [{ x: '7' }] };
+    expect(evaluateObject(`a has x = "7"`, val)).toBe(true);
+    val = { a: [{ x: 7 }, { y: 9 }] };
+    expect(evaluateObject(`a has x = 7`, val)).toBe(true);
+    val = { a: [{ x: 7 }, { x: 7 }] };
+    expect(evaluateObject(`a has x = 7`, val)).toBe(true);
+    val = { a: [{ x: 7 }, { y: 9 }] };
+    expect(evaluateObject(`a has x = 5 or a has y = 9`, val)).toBe(true);
+    val = { a: [{ x: 7 }, { y: 9 }] };
+    expect(evaluateObject(`a has x = 5 and a has y = 9`, val)).toBe(false);
+    val = { a: 2 };
+    expect(evaluateObject(`a has x = 5 or a has y = 9 and b = 8`, val)).toBe(
+      false
+    );
+    val = { a: [{ x: 5 }, { x: 4 }, { y: 8 }], b: 8 };
+    expect(evaluateObject(`a has x = 5 or a has y = 9 and b = 8`, val)).toBe(
+      true
+    );
+    val = { a: [2, 3, 4], b: 8 };
+    expect(evaluateObject(`a has 5 or a has 2 and b = 8`, val)).toBe(true);
+    val = { a: [2, 3, 4], b: 8 };
+    expect(evaluateObject(`a has 5 and a has 2 or b = 8`, val)).toBe(false);
+    val = { a: [2, 3, 4], b: 8 };
+    expect(evaluateObject(`a has 5 and a has 2 and b = 8`, val)).toBe(false);
+    val = { a: ['2', 3, 4], b: 8 };
+    expect(evaluateObject(`a has 4 and a has 2 and b = 8`, val)).toBe(false);
+    val = { a: ['5'], b: 8 };
+    expect(evaluateObject(`a has "5" and b = 8`, val)).toBe(true);
+    val = { a: ['5', { x: 2 }], b: 8 };
+    expect(evaluateObject(`a has "5" or a has x = 2 and b = 8`, val)).toBe(
+      true
+    );
+    val = { a: ['5', { x: 2 }], b: 8 };
+    expect(evaluateObject(`a has "5" and a has x = 2`, val)).toBe(true);
+    val = { a: ['5'] };
+    expect(evaluateObject(`a has "5" or a has 3`, val)).toBe(true);
+    val = { a: ['5'] };
+    expect(evaluateObject(`a has "5" and a has 3`, val)).toBe(false);
+    val = {};
+    expect(evaluateObject(`a has "5" and a has 3`, val)).toBe(false);
+    val = { a: {} };
+    expect(evaluateObject(`a has "5" or a has 3`, val)).toBe(false);
+    val = { a: { x: 5 } };
+    expect(evaluateObject(`a has "5" or a has 3`, val)).toBe(false);
+    val = {};
+    expect(evaluateObject(`a has "5" or a has 3`, val)).toBe(false);
+    val = {};
+    expect(evaluateObject(`a not has "5" or a has 3`, val)).toBe(false);
+    val = { a: [{ x: 5 }, { x: 2 }] };
+    expect(evaluateObject(`a not has x = 5`, val)).toBe(false);
+    val = { a: { x: 5 } };
+    expect(evaluateObject(`a not has x = 5 or a has 3`, val)).toBe(false);
+    val = { a: [{ x: 5 }, { x: 2 }] };
+    expect(evaluateObject(`a not has x = 5 or a has x = 2`, val)).toBe(true);
+    val = { a: [{ x: 5 }, { x: 2 }] };
+    expect(evaluateObject(`a not has x = 5 and a not has x = 2`, val)).toBe(
+      false
+    );
+    val = { a: [{ x: 1 }, { x: 4 }] };
+    expect(evaluateObject(`a not has x = 5 and a not has x = 2`, val)).toBe(
+      true
+    );
   });
 });

--- a/tests/evaluator.spec.ts
+++ b/tests/evaluator.spec.ts
@@ -33,12 +33,7 @@ describe('Evaluator tests', () => {
 
   it('should validate string range', () => {
     const val = { a: 'xyz', b: 'asd123asd' };
-    expect(
-      evaluateObject(
-        'length(a) between 1 and 3 and length(b) between 1 and 9',
-        val
-      )
-    ).toBe(true);
+    expect(evaluateObject('length(a) between 1 and 3 and length(b) between 1 and 9', val)).toBe(true);
   });
 
   it('should check string length', () => {
@@ -58,32 +53,20 @@ describe('Evaluator tests', () => {
 
   it('should check string is not null and has length between 4 and 10', () => {
     const val = { a: '1234' };
-    expect(
-      evaluateObject('a is not null and length(a) between 4 and 10', val)
-    ).toBe(true);
+    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(true);
   });
 
   it('should check string is not null and has length between 4 and 10', () => {
     let val: any = { a: null };
-    expect(
-      evaluateObject('a is not null and length(a) between 4 and 10', val)
-    ).toBe(false);
+    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(false);
     val = { a: '123' };
-    expect(
-      evaluateObject('a is not null and length(a) between 4 and 10', val)
-    ).toBe(false);
+    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(false);
     val = { a: '1234' };
-    expect(
-      evaluateObject('a is not null and length(a) between 4 and 10', val)
-    ).toBe(true);
+    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(true);
     val = { a: '1234567890' };
-    expect(
-      evaluateObject('a is not null and length(a) between 4 and 10', val)
-    ).toBe(true);
+    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(true);
     val = { a: '12345678901' };
-    expect(
-      evaluateObject('a is not null and length(a) between 4 and 10', val)
-    ).toBe(false);
+    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(false);
   });
 
   it('should compare variables', () => {
@@ -107,26 +90,13 @@ describe('Evaluator tests', () => {
   });
   it('should evaluate case expressions', () => {
     let val: any = { a: 1, b: 3 };
-    expect(
-      evaluateObject('case when a > 1 then true else false end', val)
-    ).toBe(false);
+    expect(evaluateObject('case when a > 1 then true else false end', val)).toBe(false);
     val = { a: 2, b: 3 };
-    expect(
-      evaluateObject('case when a > 1 then true else false end', val)
-    ).toBe(true);
+    expect(evaluateObject('case when a > 1 then true else false end', val)).toBe(true);
     val = { a: 2, b: 3 };
-    expect(
-      evaluateObject(
-        'case when a = 1 then 1 when a = 2 then 1 else false end',
-        val
-      )
-    ).toBe(1);
-    expect(
-      evaluateObject('case when a = 1 then 1 when a = 2 then 2 else 3 end', val)
-    ).toBe(2);
-    expect(
-      evaluateObject('case when a = 1 then 1 when a = 3 then 3 else 2 end', val)
-    ).toBe(2);
+    expect(evaluateObject('case when a = 1 then 1 when a = 2 then 1 else false end', val)).toBe(1);
+    expect(evaluateObject('case when a = 1 then 1 when a = 2 then 2 else 3 end', val)).toBe(2);
+    expect(evaluateObject('case when a = 1 then 1 when a = 3 then 3 else 2 end', val)).toBe(2);
     const rule = `case
                     when light = 'Green' then 'Go'
                     when light = 'Yellow' then 'Should Stop'
@@ -147,13 +117,9 @@ describe('Evaluator tests', () => {
     expect(evaluateObject(`a in (1,2) or b in (2,4)`, val)).toBe(true);
     expect(evaluateObject(`a in (2,3) or b in (4,5)`, val)).toBe(false);
     val = { a: 3 };
-    expect(() => evaluateObject(`b in (1,2,3,4,5)`, val)).toThrowError(
-      'b is not defined'
-    );
+    expect(() => evaluateObject(`b in (1,2,3,4,5)`, val)).toThrowError('b is not defined');
     val = { a: 3 };
-    expect(() => evaluateObject(`(1,2,3,4,5) in b`, val)).toThrowError(
-      'b is not defined'
-    );
+    expect(() => evaluateObject(`(1,2,3,4,5) in b`, val)).toThrowError('b is not defined');
     val = { a: ['one', 'two', 'three'] };
     expect(evaluateObject(`a in (1,2,3)`, val)).toBe(false);
     expect(evaluateObject(`a in ('one', 'two', 'three')`, val)).toBe(true);
@@ -162,9 +128,7 @@ describe('Evaluator tests', () => {
     val = { a: 'green' };
     expect(evaluateObject(`a not in ('blue','green','red')`, val)).toBe(false);
     val = { a: 'green' };
-    expect(() =>
-      evaluateObject(`b not in ('blue','green','red')`, val)
-    ).toThrowError('b is not defined');
+    expect(() => evaluateObject(`b not in ('blue','green','red')`, val)).toThrowError('b is not defined');
     val = { a: ['green'] };
     expect(evaluateObject(`('blue','green','red') in a`, val)).toBe(false);
     val = { a: ['green'] };
@@ -174,12 +138,10 @@ describe('Evaluator tests', () => {
     val = { a: 'green' };
     expect(evaluateObject(`a in ('green','blue','yellow')`, val)).toBe(true);
     val = { a: 'green' };
-    expect(() =>
-      evaluateObject(`b in ('green','blue','yellow')`, val)
-    ).toThrowError('b is not defined');
+    expect(() => evaluateObject(`b in ('green','blue','yellow')`, val)).toThrowError('b is not defined');
     val = { a: 'green' };
-    expect(() =>
-      evaluateObject(`('green','blue','yellow') not in a`, val)
-    ).toThrowError('Right side of IN expression must be an array');
+    expect(() => evaluateObject(`('green','blue','yellow') not in a`, val)).toThrowError(
+      'Right side of IN expression must be an array'
+    );
   });
 });

--- a/tests/evaluator.spec.ts
+++ b/tests/evaluator.spec.ts
@@ -142,30 +142,44 @@ describe('Evaluator tests', () => {
     expect(evaluateObject(rule, val)).toBe('Invalid State');
   });
   it('should evaluate in expressions', () => {
-    let val: any = { a: 1, b: 3, c: [2, 3, 5] };
-    expect(evaluateObject(`b in (1,2,3,4,5)`, val)).toBe(true);
-    val = { light: 'Blue' };
+    let val: any = { a: 1, b: 3 };
+    expect(evaluateObject(`a in (1,2) or b in (2,3)`, val)).toBe(true);
+    expect(evaluateObject(`a in (1,2) or b in (2,4)`, val)).toBe(true);
+    expect(evaluateObject(`a in (2,3) or b in (4,5)`, val)).toBe(false);
+    val = { a: 3 };
     expect(() => evaluateObject(`b in (1,2,3,4,5)`, val)).toThrowError(
       'b is not defined'
     );
-    val = { b: ['oj', 'oj', 'pl'] };
-    expect(evaluateObject(`b in (1,2,3,4,5)`, val)).toBe(false);
-    expect(evaluateObject(`b in (oj,pl)`, val)).toBe(false);
-    val = { b: 'Blue' };
-    expect(evaluateObject(`b in ('Blue','Green')`, val)).toBe(true);
-    val = { b: 'Green' };
-    expect(evaluateObject(`b in ('Blue','Green', "Yellow")`, val)).toBe(true);
-    val = { b: 'Green' };
-    expect(evaluateObject(`b not in ('Blue','Green', "RED")`, val)).toBe(false);
-    val = { a: 'Green' };
+    val = { a: 3 };
+    expect(() => evaluateObject(`(1,2,3,4,5) in b`, val)).toThrowError(
+      'b is not defined'
+    );
+    val = { a: ['one', 'two', 'three'] };
+    expect(evaluateObject(`a in (1,2,3)`, val)).toBe(false);
+    expect(evaluateObject(`a in ('one', 'two', 'three')`, val)).toBe(true);
+    val = { a: 'blue' };
+    expect(evaluateObject(`a in ('blue','green')`, val)).toBe(true);
+    val = { a: 'green' };
+    expect(evaluateObject(`a not in ('blue','green','red')`, val)).toBe(false);
+    val = { a: 'green' };
     expect(() =>
-      evaluateObject(`b not in ('Blue','Green', "RED")`, val)
+      evaluateObject(`b not in ('blue','green','red')`, val)
     ).toThrowError('b is not defined');
-    val = { a: ['Green'] };
-    expect(evaluateObject(`('Blue','Green', "RED") in a`, val)).toBe(false);
-    val = { a: ['Green'], b: 'Text', c: 'Hold the line' };
+    val = { a: ['green'] };
+    expect(evaluateObject(`('blue','green','red') in a`, val)).toBe(false);
+    val = { a: ['green'] };
     expect(evaluateObject(`(1,2,3) in a`, val)).toBe(false);
-    val = { a: ['Green'], b: 'Text', c: 'Hold the line' };
-    expect(evaluateObject(`a in ('Green', "Blue", "Yellow")`, val)).toBe(true);
+    val = { a: ['green', 'blue'] };
+    expect(evaluateObject(`a in ('green','blue','yellow')`, val)).toBe(true);
+    val = { a: 'green' };
+    expect(evaluateObject(`a in ('green','blue','yellow')`, val)).toBe(true);
+    val = { a: 'green' };
+    expect(() =>
+      evaluateObject(`b in ('green','blue','yellow')`, val)
+    ).toThrowError('b is not defined');
+    val = { a: 'green' };
+    expect(() =>
+      evaluateObject(`('green','blue','yellow') not in a`, val)
+    ).toThrowError('Right side of IN expression must be an array');
   });
 });

--- a/tests/evaluator.spec.ts
+++ b/tests/evaluator.spec.ts
@@ -143,10 +143,11 @@ describe('Evaluator tests', () => {
   });
   it('should evaluate in expressions', () => {
     let val: any = { a: 1, b: 3, c: [2, 3, 5] };
-    const rule = `b in (1,2,3,4,5)`;
     expect(evaluateObject(`b in (1,2,3,4,5)`, val)).toBe(true);
     val = { light: 'Blue' };
-    expect(evaluateObject(`b in (1,2,3,4,5)`, val)).toBe(false);
+    expect(() => evaluateObject(`b in (1,2,3,4,5)`, val)).toThrowError(
+      'b is not defined'
+    );
     val = { b: ['oj', 'oj', 'pl'] };
     expect(evaluateObject(`b in (1,2,3,4,5)`, val)).toBe(false);
     expect(evaluateObject(`b in (oj,pl)`, val)).toBe(false);
@@ -157,76 +158,14 @@ describe('Evaluator tests', () => {
     val = { b: 'Green' };
     expect(evaluateObject(`b not in ('Blue','Green', "RED")`, val)).toBe(false);
     val = { a: 'Green' };
-    expect(evaluateObject(`b not in ('Blue','Green', "RED")`, val)).toBe(false);
-  });
-  it('should evaluate has expressions', () => {
-    let val: any = { a: { x: 7 } };
-    expect(evaluateObject(`a has x = 7`, val)).toBe(true);
-    val = { a: [] };
-    expect(evaluateObject(`a has x = 7`, val)).toBe(false);
-    val = { a: [{ x: 8 }] };
-    expect(evaluateObject(`a has x = 7`, val)).toBe(false);
-    val = { a: [{ x: '7' }] };
-    expect(evaluateObject(`a has x = "7"`, val)).toBe(true);
-    val = { a: [{ x: 7 }, { y: 9 }] };
-    expect(evaluateObject(`a has x = 7`, val)).toBe(true);
-    val = { a: [{ x: 7 }, { x: 7 }] };
-    expect(evaluateObject(`a has x = 7`, val)).toBe(true);
-    val = { a: [{ x: 7 }, { y: 9 }] };
-    expect(evaluateObject(`a has x = 5 or a has y = 9`, val)).toBe(true);
-    val = { a: [{ x: 7 }, { y: 9 }] };
-    expect(evaluateObject(`a has x = 5 and a has y = 9`, val)).toBe(false);
-    val = { a: 2 };
-    expect(evaluateObject(`a has x = 5 or a has y = 9 and b = 8`, val)).toBe(
-      false
-    );
-    val = { a: [{ x: 5 }, { x: 4 }, { y: 8 }], b: 8 };
-    expect(evaluateObject(`a has x = 5 or a has y = 9 and b = 8`, val)).toBe(
-      true
-    );
-    val = { a: [2, 3, 4], b: 8 };
-    expect(evaluateObject(`a has 5 or a has 2 and b = 8`, val)).toBe(true);
-    val = { a: [2, 3, 4], b: 8 };
-    expect(evaluateObject(`a has 5 and a has 2 or b = 8`, val)).toBe(false);
-    val = { a: [2, 3, 4], b: 8 };
-    expect(evaluateObject(`a has 5 and a has 2 and b = 8`, val)).toBe(false);
-    val = { a: ['2', 3, 4], b: 8 };
-    expect(evaluateObject(`a has 4 and a has 2 and b = 8`, val)).toBe(false);
-    val = { a: ['5'], b: 8 };
-    expect(evaluateObject(`a has "5" and b = 8`, val)).toBe(true);
-    val = { a: ['5', { x: 2 }], b: 8 };
-    expect(evaluateObject(`a has "5" or a has x = 2 and b = 8`, val)).toBe(
-      true
-    );
-    val = { a: ['5', { x: 2 }], b: 8 };
-    expect(evaluateObject(`a has "5" and a has x = 2`, val)).toBe(true);
-    val = { a: ['5'] };
-    expect(evaluateObject(`a has "5" or a has 3`, val)).toBe(true);
-    val = { a: ['5'] };
-    expect(evaluateObject(`a has "5" and a has 3`, val)).toBe(false);
-    val = {};
-    expect(evaluateObject(`a has "5" and a has 3`, val)).toBe(false);
-    val = { a: {} };
-    expect(evaluateObject(`a has "5" or a has 3`, val)).toBe(false);
-    val = { a: { x: 5 } };
-    expect(evaluateObject(`a has "5" or a has 3`, val)).toBe(false);
-    val = {};
-    expect(evaluateObject(`a has "5" or a has 3`, val)).toBe(false);
-    val = {};
-    expect(evaluateObject(`a not has "5" or a has 3`, val)).toBe(false);
-    val = { a: [{ x: 5 }, { x: 2 }] };
-    expect(evaluateObject(`a not has x = 5`, val)).toBe(false);
-    val = { a: { x: 5 } };
-    expect(evaluateObject(`a not has x = 5 or a has 3`, val)).toBe(false);
-    val = { a: [{ x: 5 }, { x: 2 }] };
-    expect(evaluateObject(`a not has x = 5 or a has x = 2`, val)).toBe(true);
-    val = { a: [{ x: 5 }, { x: 2 }] };
-    expect(evaluateObject(`a not has x = 5 and a not has x = 2`, val)).toBe(
-      false
-    );
-    val = { a: [{ x: 1 }, { x: 4 }] };
-    expect(evaluateObject(`a not has x = 5 and a not has x = 2`, val)).toBe(
-      true
-    );
+    expect(() =>
+      evaluateObject(`b not in ('Blue','Green', "RED")`, val)
+    ).toThrowError('b is not defined');
+    val = { a: ['Green'] };
+    expect(evaluateObject(`('Blue','Green', "RED") in a`, val)).toBe(false);
+    val = { a: ['Green'], b: 'Text', c: 'Hold the line' };
+    expect(evaluateObject(`(1,2,3) in a`, val)).toBe(false);
+    val = { a: ['Green'], b: 'Text', c: 'Hold the line' };
+    expect(evaluateObject(`a in ('Green', "Blue", "Yellow")`, val)).toBe(true);
   });
 });

--- a/tests/evaluator.spec.ts
+++ b/tests/evaluator.spec.ts
@@ -1,15 +1,15 @@
-import { evaluate, evaluateObject } from '../src/evaluator';
+import {evaluate, evaluateObject} from "../src/evaluator";
 
-describe('Evaluator tests', () => {
-  it('should solve basic math equations', () => {
-    expect(evaluate('1+2')).toBe(3);
-    expect(evaluate('10 + 2 * 6')).toBe(22);
-    expect(evaluate('100 * 2 + 12')).toBe(212);
-    expect(evaluate('100 * ( 2 + 12 )')).toBe(1400);
-    expect(evaluate('100 * ( 2 + 12 ) / 14')).toBe(100);
+describe("Evaluator tests", () => {
+  it("should solve basic math equations", () => {
+    expect(evaluate("1+2")).toBe(3);
+    expect(evaluate("10 + 2 * 6")).toBe(22);
+    expect(evaluate("100 * 2 + 12")).toBe(212);
+    expect(evaluate("100 * ( 2 + 12 )")).toBe(1400);
+    expect(evaluate("100 * ( 2 + 12 ) / 14")).toBe(100);
   });
 
-  it('should solve basic math equations with object context', () => {
+  it("should solve basic math equations with object context", () => {
     const context = {
       a: 1,
       b: 2,
@@ -19,129 +19,167 @@ describe('Evaluator tests', () => {
       f: 12,
       g: 14,
     };
-    expect(evaluateObject('a+b', context)).toBe(3);
-    expect(evaluateObject('c + b * d', context)).toBe(22);
-    expect(evaluateObject('e * b + f', context)).toBe(212);
-    expect(evaluateObject('e * ( b + f )', context)).toBe(1400);
-    expect(evaluateObject('e * ( b + f ) / g', context)).toBe(100);
+    expect(evaluateObject("a+b", context)).toBe(3);
+    expect(evaluateObject("c + b * d", context)).toBe(22);
+    expect(evaluateObject("e * b + f", context)).toBe(212);
+    expect(evaluateObject("e * ( b + f )", context)).toBe(1400);
+    expect(evaluateObject("e * ( b + f ) / g", context)).toBe(100);
   });
 
-  it('should resolve length of string', () => {
-    const val = { a: 'xyz' };
-    expect(evaluateObject('length(a)', val)).toBe(3);
+  it("should resolve length of string", () => {
+    const val = {a: "xyz"};
+    expect(evaluateObject("length(a)", val)).toBe(3);
   });
 
-  it('should validate string range', () => {
-    const val = { a: 'xyz', b: 'asd123asd' };
-    expect(evaluateObject('length(a) between 1 and 3 and length(b) between 1 and 9', val)).toBe(true);
+  it("should validate string range", () => {
+    const val = {a: "xyz", b: "asd123asd"};
+    expect(
+      evaluateObject(
+        "length(a) between 1 and 3 and length(b) between 1 and 9",
+        val
+      )
+    ).toBe(true);
   });
 
-  it('should check string length', () => {
-    const val = { a: 'asd123asd' };
-    expect(evaluateObject('length(a) = 9', val)).toBe(true);
+  it("should check string length", () => {
+    const val = {a: "asd123asd"};
+    expect(evaluateObject("length(a) = 9", val)).toBe(true);
   });
 
-  it('should check not null', () => {
-    const val = { a: 'asd123asd' };
-    expect(evaluateObject('a is not null', val)).toBe(true);
+  it("should check not null", () => {
+    const val = {a: "asd123asd"};
+    expect(evaluateObject("a is not null", val)).toBe(true);
   });
 
-  it('should check not null', () => {
-    const val = { a: null };
-    expect(evaluateObject('a is null', val)).toBe(true);
+  it("should check not null", () => {
+    const val = {a: null};
+    expect(evaluateObject("a is null", val)).toBe(true);
   });
 
-  it('should check string is not null and has length between 4 and 10', () => {
-    const val = { a: '1234' };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(true);
+  it("should check string is not null and has length between 4 and 10", () => {
+    const val = {a: "1234"};
+    expect(
+      evaluateObject("a is not null and length(a) between 4 and 10", val)
+    ).toBe(true);
   });
 
-  it('should check string is not null and has length between 4 and 10', () => {
-    let val: any = { a: null };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(false);
-    val = { a: '123' };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(false);
-    val = { a: '1234' };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(true);
-    val = { a: '1234567890' };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(true);
-    val = { a: '12345678901' };
-    expect(evaluateObject('a is not null and length(a) between 4 and 10', val)).toBe(false);
+  it("should check string is not null and has length between 4 and 10", () => {
+    let val: any = {a: null};
+    expect(
+      evaluateObject("a is not null and length(a) between 4 and 10", val)
+    ).toBe(false);
+    val = {a: "123"};
+    expect(
+      evaluateObject("a is not null and length(a) between 4 and 10", val)
+    ).toBe(false);
+    val = {a: "1234"};
+    expect(
+      evaluateObject("a is not null and length(a) between 4 and 10", val)
+    ).toBe(true);
+    val = {a: "1234567890"};
+    expect(
+      evaluateObject("a is not null and length(a) between 4 and 10", val)
+    ).toBe(true);
+    val = {a: "12345678901"};
+    expect(
+      evaluateObject("a is not null and length(a) between 4 and 10", val)
+    ).toBe(false);
   });
 
-  it('should compare variables', () => {
-    let val: any = { a: 1, b: 1 };
-    expect(evaluateObject('a is not null and b is not null', val)).toBe(true);
-    expect(evaluateObject('a is not null and b is null', val)).toBe(false);
+  it("should compare variables", () => {
+    let val: any = {a: 1, b: 1};
+    expect(evaluateObject("a is not null and b is not null", val)).toBe(true);
+    expect(evaluateObject("a is not null and b is null", val)).toBe(false);
 
-    val = { a: 1, b: null };
-    expect(evaluateObject('a is not null and b is null', val)).toBe(true);
+    val = {a: 1, b: null};
+    expect(evaluateObject("a is not null and b is null", val)).toBe(true);
 
-    val = { a: 1, b: 1 };
-    expect(evaluateObject('a=b', val)).toBe(true);
-    expect(evaluateObject('a>b', val)).toBe(false);
-    expect(evaluateObject('a<b', val)).toBe(false);
+    val = {a: 1, b: 1};
+    expect(evaluateObject("a=b", val)).toBe(true);
+    expect(evaluateObject("a>b", val)).toBe(false);
+    expect(evaluateObject("a<b", val)).toBe(false);
 
-    val = { a: 1, b: 2 };
-    expect(evaluateObject('a=b', val)).toBe(false);
-    expect(evaluateObject('a>b', val)).toBe(false);
-    expect(evaluateObject('a<b', val)).toBe(true);
-    expect(evaluateObject('a>=1 and a< 10 and b >1 and b<3', val)).toBe(true);
+    val = {a: 1, b: 2};
+    expect(evaluateObject("a=b", val)).toBe(false);
+    expect(evaluateObject("a>b", val)).toBe(false);
+    expect(evaluateObject("a<b", val)).toBe(true);
+    expect(evaluateObject("a>=1 and a< 10 and b >1 and b<3", val)).toBe(true);
   });
-  it('should evaluate case expressions', () => {
-    let val: any = { a: 1, b: 3 };
-    expect(evaluateObject('case when a > 1 then true else false end', val)).toBe(false);
-    val = { a: 2, b: 3 };
-    expect(evaluateObject('case when a > 1 then true else false end', val)).toBe(true);
-    val = { a: 2, b: 3 };
-    expect(evaluateObject('case when a = 1 then 1 when a = 2 then 1 else false end', val)).toBe(1);
-    expect(evaluateObject('case when a = 1 then 1 when a = 2 then 2 else 3 end', val)).toBe(2);
-    expect(evaluateObject('case when a = 1 then 1 when a = 3 then 3 else 2 end', val)).toBe(2);
+  it("should evaluate case expressions", () => {
+    let val: any = {a: 1, b: 3};
+    expect(
+      evaluateObject("case when a > 1 then true else false end", val)
+    ).toBe(false);
+    val = {a: 2, b: 3};
+    expect(
+      evaluateObject("case when a > 1 then true else false end", val)
+    ).toBe(true);
+    val = {a: 2, b: 3};
+    expect(
+      evaluateObject(
+        "case when a = 1 then 1 when a = 2 then 1 else false end",
+        val
+      )
+    ).toBe(1);
+    expect(
+      evaluateObject("case when a = 1 then 1 when a = 2 then 2 else 3 end", val)
+    ).toBe(2);
+    expect(
+      evaluateObject("case when a = 1 then 1 when a = 3 then 3 else 2 end", val)
+    ).toBe(2);
     const rule = `case
                     when light = 'Green' then 'Go'
                     when light = 'Yellow' then 'Should Stop'
                     when light = 'Red' then 'Stop'
                     else 'Invalid State' end`;
-    val = { light: 'Yellow' };
-    expect(evaluateObject(rule, val)).toBe('Should Stop');
-    val = { light: 'Green' };
-    expect(evaluateObject(rule, val)).toBe('Go');
-    val = { light: 'Red' };
-    expect(evaluateObject(rule, val)).toBe('Stop');
-    val = { light: 'Blue' };
-    expect(evaluateObject(rule, val)).toBe('Invalid State');
+    val = {light: "Yellow"};
+    expect(evaluateObject(rule, val)).toBe("Should Stop");
+    val = {light: "Green"};
+    expect(evaluateObject(rule, val)).toBe("Go");
+    val = {light: "Red"};
+    expect(evaluateObject(rule, val)).toBe("Stop");
+    val = {light: "Blue"};
+    expect(evaluateObject(rule, val)).toBe("Invalid State");
   });
-  it('should evaluate in expressions', () => {
-    let val: any = { a: 1, b: 3 };
+  it("should evaluate in expressions", () => {
+    let val: any = {a: 1, b: 3};
     expect(evaluateObject(`a in (1,2) or b in (2,3)`, val)).toBe(true);
     expect(evaluateObject(`a in (1,2) or b in (2,4)`, val)).toBe(true);
     expect(evaluateObject(`a in (2,3) or b in (4,5)`, val)).toBe(false);
-    val = { a: 3 };
-    expect(() => evaluateObject(`b in (1,2,3,4,5)`, val)).toThrowError('b is not defined');
-    val = { a: 3 };
-    expect(() => evaluateObject(`(1,2,3,4,5) in b`, val)).toThrowError('b is not defined');
-    val = { a: ['one', 'two', 'three'] };
+    val = {a: 3};
+    expect(() => evaluateObject(`b in (1,2,3,4,5)`, val)).toThrowError(
+      "b is not defined"
+    );
+    val = {a: 3};
+    expect(() => evaluateObject(`(1,2,3,4,5) in b`, val)).toThrowError(
+      "b is not defined"
+    );
+    val = {a: ["one", "two", "three"]};
     expect(evaluateObject(`a in (1,2,3)`, val)).toBe(false);
     expect(evaluateObject(`a in ('one', 'two', 'three')`, val)).toBe(true);
-    val = { a: 'blue' };
+    val = {a: "blue"};
     expect(evaluateObject(`a in ('blue','green')`, val)).toBe(true);
-    val = { a: 'green' };
+    val = {a: "green"};
     expect(evaluateObject(`a not in ('blue','green','red')`, val)).toBe(false);
-    val = { a: 'green' };
-    expect(() => evaluateObject(`b not in ('blue','green','red')`, val)).toThrowError('b is not defined');
-    val = { a: ['green'] };
+    val = {a: "green"};
+    expect(() =>
+      evaluateObject(`b not in ('blue','green','red')`, val)
+    ).toThrowError("b is not defined");
+    val = {a: ["green"]};
     expect(evaluateObject(`('blue','green','red') in a`, val)).toBe(false);
-    val = { a: ['green'] };
+    val = {a: ["green"]};
     expect(evaluateObject(`(1,2,3) in a`, val)).toBe(false);
-    val = { a: ['green', 'blue'] };
+    val = {a: ["green", "blue"]};
     expect(evaluateObject(`a in ('green','blue','yellow')`, val)).toBe(true);
-    val = { a: 'green' };
+    val = {a: "green"};
     expect(evaluateObject(`a in ('green','blue','yellow')`, val)).toBe(true);
-    val = { a: 'green' };
-    expect(() => evaluateObject(`b in ('green','blue','yellow')`, val)).toThrowError('b is not defined');
-    val = { a: 'green' };
-    expect(() => evaluateObject(`('green','blue','yellow') not in a`, val)).toThrowError(
-      'Right side of IN expression must be an array'
-    );
+    val = {a: "green"};
+    expect(() =>
+      evaluateObject(`b in ('green','blue','yellow')`, val)
+    ).toThrowError("b is not defined");
+    val = {a: "green"};
+    expect(() =>
+      evaluateObject(`('green','blue','yellow') not in a`, val)
+    ).toThrowError("Right side of IN expression must be an array");
   });
 });

--- a/tests/lexer.spec.ts
+++ b/tests/lexer.spec.ts
@@ -62,7 +62,7 @@ describe('Lexer Tests', () => {
 
   it('should tokenize a complex expression', () => {
     const lexer = new Lexer(
-      'a>1 and b<c or g <> "xyz" ( a + b - c *d /f) <> abc  and a > 1.3 a>= .1988 and bxx<=2 and e=true not FALSE is between 1 null and b in (1,2,3) or a has x = 5 or a not has 9'
+      'a>1 and b<c or g <> "xyz" ( a + b - c *d /f) <> abc  and a > 1.3 a>= .1988 and bxx<=2 and e=true not FALSE is between 1 null and b in (1,2,3)'
     );
     const expected: Token[] = [
       new Token(TokenType.Identifier, 'a', 0),
@@ -120,20 +120,7 @@ describe('Lexer Tests', () => {
       new Token(TokenType.Comma, ',', 138),
       new Token(TokenType.Numeric, '3', 139),
       new Token(TokenType.Rparn, ')', 140),
-
-      new Token(TokenType.Or, 'or', 142),
-      new Token(TokenType.Identifier, 'a', 145),
-      new Token(TokenType.Has, 'has', 147),
-      new Token(TokenType.Identifier, 'x', 151),
-      new Token(TokenType.Eq, '=', 153),
-      new Token(TokenType.Numeric, '5', 155),
-
-      new Token(TokenType.Or, 'or', 157),
-      new Token(TokenType.Identifier, 'a', 160),
-      new Token(TokenType.Not, 'not', 162),
-      new Token(TokenType.Has, 'has', 166),
-      new Token(TokenType.Numeric, '9', 170),
-      new Token(TokenType.EOF, '\0', 171),
+      new Token(TokenType.EOF, '\0', 141),
     ];
 
     expected.forEach((tok) => {

--- a/tests/lexer.spec.ts
+++ b/tests/lexer.spec.ts
@@ -62,7 +62,7 @@ describe('Lexer Tests', () => {
 
   it('should tokenize a complex expression', () => {
     const lexer = new Lexer(
-      'a>1 and b<c or g <> "xyz" ( a + b - c *d /f) <> abc  and a > 1.3 a>= .1988 and bxx<=2 and e=true not FALSE is between 1 null',
+      'a>1 and b<c or g <> "xyz" ( a + b - c *d /f) <> abc  and a > 1.3 a>= .1988 and bxx<=2 and e=true not FALSE is between 1 null and b in (1,2,3) or a has x = 5 or a not has 9'
     );
     const expected: Token[] = [
       new Token(TokenType.Identifier, 'a', 0),
@@ -110,7 +110,30 @@ describe('Lexer Tests', () => {
       new Token(TokenType.Between, 'between', 110),
       new Token(TokenType.Numeric, '1', 118),
       new Token(TokenType.Null, 'null', 120),
-      new Token(TokenType.EOF, '\0', 124),
+      new Token(TokenType.And, 'and', 125),
+      new Token(TokenType.Identifier, 'b', 129),
+      new Token(TokenType.In, 'in', 131),
+      new Token(TokenType.Lparn, '(', 134),
+      new Token(TokenType.Numeric, '1', 135),
+      new Token(TokenType.Comma, ',', 136),
+      new Token(TokenType.Numeric, '2', 137),
+      new Token(TokenType.Comma, ',', 138),
+      new Token(TokenType.Numeric, '3', 139),
+      new Token(TokenType.Rparn, ')', 140),
+
+      new Token(TokenType.Or, 'or', 142),
+      new Token(TokenType.Identifier, 'a', 145),
+      new Token(TokenType.Has, 'has', 147),
+      new Token(TokenType.Identifier, 'x', 151),
+      new Token(TokenType.Eq, '=', 153),
+      new Token(TokenType.Numeric, '5', 155),
+
+      new Token(TokenType.Or, 'or', 157),
+      new Token(TokenType.Identifier, 'a', 160),
+      new Token(TokenType.Not, 'not', 162),
+      new Token(TokenType.Has, 'has', 166),
+      new Token(TokenType.Numeric, '9', 170),
+      new Token(TokenType.EOF, '\0', 171),
     ];
 
     expected.forEach((tok) => {


### PR DESCRIPTION
Hi Abdullah, 

Thank you for your work on this lib!
I added two expression types HasExpression and InExpression to enable syntax like the following:

`let val = { a: [{ x: '7' }] };
evaluateObject('a has x = "7"', val)`

and 

`let val: any = { a: 3};
evaluateObject('a in (1,2,3,4,5)', val)`

Let me know what you think. 
Cheers 👋 